### PR TITLE
Change permissions to write to content

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0


### PR DESCRIPTION
### Description

Update release workflow permissions

### Changes

Update permissions to write to repository content.
https://goreleaser.com/ci/actions/#token-permissions

### Related Issues

#13
